### PR TITLE
Add patch for Issue #3448075: Fix the padding for filter form wrapper div on the Git Type Tray module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,6 +178,10 @@
       "drupal/gin_everywhere": {
         "Issue #3436449: The status tab is showing out in the Are you sure you want to delete the content item page":
         "https://www.drupal.org/files/issues/2024-05-15/gin_everywhere--2024-05-15--3436449-5.patch"
+      },
+      "drupal/gin_type_tray": {
+        "Issue #3448085: Add Gin Type Tray module to Varbase Admin and enable it by default":
+        "https://www.drupal.org/files/issues/2024-05-19/gin_type_tray--2024-05-19--3448075-2.patch"
       }
     }
   }


### PR DESCRIPTION
… Admin and enable it by default