### PR TITLE
Remove the patch for Issue #3449903: Add the "use keysave" permission to the Keysave module to be able to control access by user roles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -182,10 +182,6 @@
       "drupal/gin_type_tray": {
         "Issue #3448075: Fix the padding for filter form wrapper div":
         "https://www.drupal.org/files/issues/2024-05-19/gin_type_tray--2024-05-19--3448075-2.patch"
-      },
-      "drupal/keysave": {
-        "Issue #3449903: Add Permissions to the module" :
-        "https://www.drupal.org/files/issues/2024-05-26/keysave--2024-05-26--3449903-3.patch" 
       }
     }
   }


### PR DESCRIPTION
Dropping the logic of [#3449903: Add the "use keysave" permission to the Keysave module to be able to control access by user roles](https://www.drupal.org/project/keysave/issues/3449903)
Moving to have a default set included and Excluded forms after
[#3449936: Allow configuration of forms to include and exclude](https://www.drupal.org/project/keysave/issues/3449936)