### PR TITLE
Change the patch for Layout Builder Blocks on Issue #3349066: Limit Layout Builder Blocks not to work in the dashboards route to Allow to both Dashboards and the new Dashboard module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
       },
       "drupal/layout_builder_blocks": {
         "Issue #3349066: Limit Layout Builder Blocks not to work in the dashboards route":
-        "https://www.drupal.org/files/issues/2024-08-14/layout_builder_blocks--2024-08-14--3349066--mr-5.patch"
+        "https://www.drupal.org/files/issues/2025-06-22/layout_builder_blocks--2025-06-22--3349066--mr-5.patch"
       },
       "drupal/paragraphs": {
         "Issue #2924774: Let Editors add/delete/clone paragraphs When [Editing a translation]":


### PR DESCRIPTION

Issue [#3349066](https://www.drupal.org/project/layout_builder_blocks/issues/3349066): Limit Layout Builder Blocks not to work in the dashboards route