### PR TITLE
Add a patch for Drupal Core on Issue #3415961: [drupalMedia] Using the Insert Media button causes the window to scroll to the bottom of the page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,9 @@
         "Issue #3496329: Fix not loading CKEditor 5 and Tour with BigPipe enabled after Drupal 10.4 update":
         "https://www.drupal.org/files/issues/2025-01-03/drupal-core--2025-01-02--3496329-32--mr-10753.patch",
         "Issue #3352384: Add Exception for TypeError Argument must be String in Drupal Component Utility Html escape{}":
-        "https://www.drupal.org/files/issues/2024-11-07/TypeError_htmlspecialchars_ArgumentNustBeTypeString_ArrayGiven-3352384-62.patch"
+        "https://www.drupal.org/files/issues/2024-11-07/TypeError_htmlspecialchars_ArgumentNustBeTypeString_ArrayGiven-3352384-62.patch",
+        "Issue #3415961: [drupalMedia] Using the Insert Media button causes the window to scroll to the bottom of the page":
+        "https://www.drupal.org/files/issues/2025-06-10/drupal-3415961-19.patch"
       },
       "drupal/default_content": {
         "Issue #3160146: Add Layout Builder Normalizer and Denormalize":


### PR DESCRIPTION
Issue [#3415961](https://www.drupal.org/project/drupal/issues/3415961): [drupalMedia] Using the Insert Media button causes the window to scroll to the bottom of the page