### PR TITLE
Remove a patch for Media Bulk Upload on fix: #3542595 Implicit nullable Request parameter for PHP 8.4 compatibility in Media Bulk Upload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -233,10 +233,6 @@
         "fix: #3561953 PHP 8.4 implicit nullable & constructor parameter order issues in WebP FileDownloadController":
         "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/webp--2025-12-08--mr-54.patch"
       },
-      "drupal/media_bulk_upload": {
-        "fix: #3542595 Implicit nullable Request parameter for PHP 8.4 compatibility in Media Bulk Upload":
-        "https://git.drupalcode.org/project/media_bulk_upload/-/commit/d63a897ce07b11e94fe08d5d309b49bb5ee8af43.diff"
-      },
       "drupal/userprotect": {
         "Issue #3510800: (PHP 8.4) Fixed implicitly marking parameter $items as nullable is deprecated in userprotect_entity_field_access()":
         "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/userprotect--2026-01-20--3510800--mr-11.patch"


### PR DESCRIPTION
**[Media Bulk Upload](https://www.drupal.org/project/media_bulk_upload) 3.0.5** was released on: 19 Jan 2026 by: [jannakha](https://www.drupal.org/user/3085703)

---

fix: [#3542595](https://www.drupal.org/project/media_bulk_upload/issues/3542595) Implicit nullable Request parameter for PHP 8.4 compatibility in Media Bulk Upload